### PR TITLE
Feature/login in two ways

### DIFF
--- a/models/auth.py
+++ b/models/auth.py
@@ -2,6 +2,6 @@ from pydantic import BaseModel
 from typing import Optional, List
 
 class Token(BaseModel):
-    token: str
+    access_token: str
     token_type: str
     roles: Optional[List] = ['ROLE_ADMIN']

--- a/routers/oauth_routers.py
+++ b/routers/oauth_routers.py
@@ -4,7 +4,7 @@ from typing import Union
 import logging
 
 import jwt
-from fastapi import APIRouter, Depends, status, Body
+from fastapi import APIRouter, Depends
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jwt import PyJWTError
 from pydantic import BaseModel
@@ -60,9 +60,14 @@ class LoginForm(BaseModel):
 
 @router.post("/login", tags=["auth"])
 def login_json(form: LoginForm):
-    data = f"username={form.username}&password={form.password}"
-    formData = OAuth2PasswordRequestForm(data)
-    return login(formData=formData)
+    """Provide the login via json format"""
+    return login(formData=OAuth2PasswordRequestForm(
+        username = form.username,
+        password = form.password,
+        scope = "",
+        client_id = None,
+        client_secret = None
+    ))
 
 
 @router.post("/token", tags=["auth"])

--- a/routers/oauth_routers.py
+++ b/routers/oauth_routers.py
@@ -31,7 +31,7 @@ def create_access_token(
     to_encode = data.copy()
     to_encode.update({"exp": expire})
     access_token = jwt.encode(to_encode, key=SECRET, algorithm=ALGORITHM)
-    return Token(token=access_token, token_type=TOKEN_TYPE)
+    return Token(access_token=access_token, token_type=TOKEN_TYPE)
 
 
 # Scheme to be used for the authentication


### PR DESCRIPTION
# Login
## Issue
The login was only possible in one way. Either with the form at the `docs` route, or via request with json format.
## Solution
Two routes are now present to get an access token.
- `/token` accepts a `Form` as the request body: `username=a_username&password=a_password`
- `/login` accepts a json formatted request body: `{"username":"a_username", "password":"a_password"}`